### PR TITLE
feat: rebrand app to WeTravel with new icon and favicon

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -101,7 +101,7 @@ const App: React.FC = () => {
           ) : (
             <div className="flex items-center gap-2 animate-in fade-in duration-300">
               <div className="w-8 h-8 bg-terracotta-500 rounded-xl flex items-center justify-center shadow-lg shadow-terracotta-500/20"><Sparkles className="w-5 h-5 text-white" /></div>
-              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WanderList</h1>
+              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WeTravel</h1>
             </div>
           )}
           <ThemeToggle />

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -66,7 +66,7 @@ const InstallPrompt: React.FC = () => {
     <div className="fixed bottom-4 left-4 z-[100] bg-white text-ocean-900 p-4 rounded-xl shadow-2xl border border-sand-200 flex items-center gap-4 animate-in slide-in-from-bottom duration-300 max-w-sm">
       <div className="flex-1">
         <h3 className="font-bold text-sm mb-1">
-          Install WanderList
+          Install WeTravel
         </h3>
         <p className="text-xs text-sand-400">
           {isIOS 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <title>WeTravel</title>
+    <link rel="icon" type="image/svg+xml" href="/icon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6"/>
+      <stop offset="100%" style="stop-color:#015a9f"/>
+    </linearGradient>
+    <linearGradient id="planeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffffff"/>
+      <stop offset="100%" style="stop-color:#e0effe"/>
+    </linearGradient>
+  </defs>
+  <!-- Background circle -->
+  <circle cx="256" cy="256" r="240" fill="url(#bgGrad)"/>
+  <!-- Airplane icon -->
+  <g transform="translate(256, 256) rotate(-45) translate(-256, -256)">
+    <path d="M432 256c0-17.7-14.3-32-32-32h-80l-96-128h-48l48 128h-96l-32-48h-48l32 80-32 80h48l32-48h96l-48 128h48l96-128h80c17.7 0 32-14.3 32-32z" 
+          fill="url(#planeGrad)" 
+          transform="translate(40, 0)"/>
+  </g>
+  <!-- Globe accent lines -->
+  <ellipse cx="256" cy="256" rx="180" ry="60" fill="none" stroke="#ffffff" stroke-width="3" opacity="0.3" transform="rotate(-20, 256, 256)"/>
+  <ellipse cx="256" cy="256" rx="140" ry="45" fill="none" stroke="#ffffff" stroke-width="2" opacity="0.2" transform="rotate(25, 256, 256)"/>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,8 +23,8 @@ export default defineConfig(({ mode }) => {
           registerType: 'prompt',
           includeAssets: ['icon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',


### PR DESCRIPTION
## Summary

Rebrands the application from "WanderList" to "WeTravel" as requested in #4.

### Changes Made

- **Page title**: Changed from "WanderList AI" to "WeTravel"
- **PWA manifest**: Updated `name` and `short_name` to "WeTravel"
- **App header**: Updated the main navigation header text
- **Install prompt**: Updated the PWA install prompt text
- **Favicon**: Added favicon link to `index.html`
- **Icon**: Created a new travel-themed SVG icon featuring:
  - Ocean blue gradient background
  - White airplane silhouette (rotated for dynamic look)
  - Subtle globe accent lines for travel context

### Files Modified

| File | Change |
|------|--------|
| `index.html` | Title + favicon link |
| `vite.config.ts` | PWA manifest name/short_name |
| `App.tsx` | Header text |
| `components/InstallPrompt.tsx` | Install prompt text |
| `public/icon.svg` | New icon design |

### Verification

- ✅ Build passes (`npm run build`)
- ✅ PWA manifest generates correctly

Closes #4