### PR TITLE
Rename app to WeTravel and add PWA icons/favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <title>WeTravel</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
-  "name": "Trip Planner",
-  "description": "A comprehensive travel companion app to organize trips, view flight itineraries, discover new places, and visualize your journey on an interactive timeline and map.",
+  "name": "WeTravel",
+  "description": "AI-powered travel companion app to organize trips, view flight itineraries, discover new places, and visualize your journey on an interactive timeline and map.",
   "requestFramePermissions": [
     "geolocation"
   ]

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6" />
+      <stop offset="100%" style="stop-color:#36aaf5" />
+    </linearGradient>
+  </defs>
+  <!-- Rounded square background -->
+  <rect x="2" y="2" width="28" height="28" rx="6" fill="url(#bg)"/>
+  <!-- Stylized W for WeTravel -->
+  <path d="M7 10 L10 22 L13.5 14 L16 22 L19.5 14 L22 22 L25 10" 
+        fill="none" 
+        stroke="white" 
+        stroke-width="2.5" 
+        stroke-linecap="round" 
+        stroke-linejoin="round"/>
+  <!-- Small plane accent -->
+  <path d="M23 8 L26 6 L27 7 L25 9 L23 8" fill="white" opacity="0.8"/>
+</svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="skyGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#36aaf5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="planeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffffff;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#e0effe;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Circle background -->
+  <circle cx="256" cy="256" r="240" fill="url(#skyGradient)"/>
+  <!-- Airplane icon -->
+  <g transform="translate(256, 256) rotate(-45) translate(-24, -24) scale(8)">
+    <path fill="url(#planeGradient)" d="M21.8,4.2c-0.5-0.5-1.3-0.8-2-0.8c-0.6,0-1.1,0.2-1.5,0.5L14,8.3L6,5v2l8,4.5v4l-3,1.5v2l4-1l4,1v-2l-3-1.5v-4L24,6C24.6,5.5,24,4.3,21.8,4.2z"/>
+  </g>
+  <!-- Globe lines for travel theme -->
+  <ellipse cx="256" cy="256" rx="180" ry="180" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="2"/>
+  <ellipse cx="256" cy="256" rx="180" ry="80" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="2"/>
+  <ellipse cx="256" cy="256" rx="80" ry="180" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="2"/>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,10 +21,10 @@ export default defineConfig(({ mode }) => {
         react(),
         VitePWA({
           registerType: 'prompt',
-          includeAssets: ['icon.svg'],
+          includeAssets: ['icon.svg', 'favicon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',


### PR DESCRIPTION
## Summary
- Renamed the app from "WanderList" to **WeTravel** throughout the codebase
- Added a new travel-themed **icon.svg** for PWA with globe lines and airplane design
- Created a **favicon.svg** with a stylized "W" logo for browser tabs
- Updated all manifest and metadata files with the new branding

## Changes
| File | Change |
|------|--------|
| `vite.config.ts` | PWA manifest name/short_name changed to "WeTravel" |
| `index.html` | Title changed to "WeTravel", added favicon link |
| `metadata.json` | Name updated to "WeTravel" |
| `public/icon.svg` | New travel-themed icon (globe + plane) |
| `public/favicon.svg` | New favicon with stylized W logo |

## Screenshots
The new icons use the ocean blue color palette (#0c8ee6 → #36aaf5) to match the app's existing design system.

Fixes #4