### PR TITLE
feat: Rebrand app to WeTravel with new icons

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -101,7 +101,7 @@ const App: React.FC = () => {
           ) : (
             <div className="flex items-center gap-2 animate-in fade-in duration-300">
               <div className="w-8 h-8 bg-terracotta-500 rounded-xl flex items-center justify-center shadow-lg shadow-terracotta-500/20"><Sparkles className="w-5 h-5 text-white" /></div>
-              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WanderList</h1>
+              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WeTravel</h1>
             </div>
           )}
           <ThemeToggle />

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -66,7 +66,7 @@ const InstallPrompt: React.FC = () => {
     <div className="fixed bottom-4 left-4 z-[100] bg-white text-ocean-900 p-4 rounded-xl shadow-2xl border border-sand-200 flex items-center gap-4 animate-in slide-in-from-bottom duration-300 max-w-sm">
       <div className="flex-1">
         <h3 className="font-bold text-sm mb-1">
-          Install WanderList
+          Install WeTravel
         </h3>
         <p className="text-xs text-sand-400">
           {isIOS 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <title>WeTravel</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6"/>
+      <stop offset="100%" style="stop-color:#015a9f"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="32" height="32" rx="6" fill="url(#bg)"/>
+  <!-- Simplified airplane -->
+  <g transform="translate(16, 16) rotate(-45) translate(-16, -16)">
+    <path d="M24 10 L22 12 L18 11 L12 17 L13 21 L10 24 L9 23 L10 19 L7 16 L5 17 L4 15 L10 12 L13 7 L15 8 L14 11 L18 8 L21 5 L24 5 L25 7 L25 10Z" 
+          fill="#ffffff"/>
+  </g>
+  <!-- Small location dot -->
+  <circle cx="24" cy="24" r="4" fill="#eb6b42" stroke="#ffffff" stroke-width="1"/>
+</svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,38 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6"/>
+      <stop offset="100%" style="stop-color:#015a9f"/>
+    </linearGradient>
+    <linearGradient id="planeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffffff"/>
+      <stop offset="100%" style="stop-color:#e0effe"/>
+    </linearGradient>
+  </defs>
+  <!-- Background circle -->
+  <circle cx="256" cy="256" r="256" fill="url(#bgGrad)"/>
+  <!-- Globe lines -->
+  <ellipse cx="256" cy="256" rx="140" ry="140" fill="none" stroke="#ffffff" stroke-width="8" opacity="0.3"/>
+  <ellipse cx="256" cy="256" rx="140" ry="70" fill="none" stroke="#ffffff" stroke-width="6" opacity="0.25"/>
+  <line x1="116" y1="256" x2="396" y2="256" stroke="#ffffff" stroke-width="6" opacity="0.25"/>
+  <line x1="256" y1="116" x2="256" y2="396" stroke="#ffffff" stroke-width="6" opacity="0.25"/>
+  <!-- Airplane -->
+  <g transform="translate(256, 256) rotate(-45) translate(-256, -256)">
+    <path d="M380 180 L340 220 L280 200 L200 280 L220 340 L180 380 L160 360 L170 300 L130 260 L90 270 L80 240 L160 200 L200 130 L230 140 L220 180 L280 140 L320 100 L360 100 L380 120 L380 180Z" 
+          fill="url(#planeGrad)" 
+          stroke="#ffffff" 
+          stroke-width="4"/>
+    <!-- Plane trail -->
+    <circle cx="100" cy="260" r="8" fill="#ffffff" opacity="0.6"/>
+    <circle cx="70" cy="290" r="6" fill="#ffffff" opacity="0.4"/>
+    <circle cx="50" cy="310" r="4" fill="#ffffff" opacity="0.2"/>
+  </g>
+  <!-- Location pin accent -->
+  <g transform="translate(340, 340)">
+    <path d="M0 -40 C22 -40 40 -22 40 0 C40 22 0 60 0 60 C0 60 -40 22 -40 0 C-40 -22 -22 -40 0 -40Z" 
+          fill="#eb6b42" 
+          stroke="#ffffff" 
+          stroke-width="4"/>
+    <circle cx="0" cy="-5" r="12" fill="#ffffff"/>
+  </g>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,10 +21,10 @@ export default defineConfig(({ mode }) => {
         react(),
         VitePWA({
           registerType: 'prompt',
-          includeAssets: ['icon.svg'],
+          includeAssets: ['icon.svg', 'favicon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',


### PR DESCRIPTION
## Summary

- Renamed the app from **WanderList** to **WeTravel** across all source files
- Created a new travel-themed SVG icon featuring a globe with airplane and location pin design
- Added `favicon.svg` for browser tab icon support
- Updated PWA manifest configuration with new app name and icons

## Changes

| File | Change |
|------|--------|
| `index.html` | Updated title to "WeTravel", added favicon link |
| `App.tsx` | Changed header branding to "WeTravel" |
| `components/InstallPrompt.tsx` | Updated install prompt text |
| `vite.config.ts` | Updated PWA manifest name and short_name |
| `public/icon.svg` | New travel-themed icon with globe, airplane, and location pin |
| `public/favicon.svg` | New compact favicon for browser tabs |

## Testing

- [x] Build passes successfully
- [x] PWA manifest contains correct "WeTravel" branding
- [x] No remaining references to "WanderList"

Closes #4