### PR TITLE
feat: Rename app to WeTravel and add favicon/PWA icons

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -101,7 +101,7 @@ const App: React.FC = () => {
           ) : (
             <div className="flex items-center gap-2 animate-in fade-in duration-300">
               <div className="w-8 h-8 bg-terracotta-500 rounded-xl flex items-center justify-center shadow-lg shadow-terracotta-500/20"><Sparkles className="w-5 h-5 text-white" /></div>
-              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WanderList</h1>
+              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WeTravel</h1>
             </div>
           )}
           <ThemeToggle />

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -66,7 +66,7 @@ const InstallPrompt: React.FC = () => {
     <div className="fixed bottom-4 left-4 z-[100] bg-white text-ocean-900 p-4 rounded-xl shadow-2xl border border-sand-200 flex items-center gap-4 animate-in slide-in-from-bottom duration-300 max-w-sm">
       <div className="flex-1">
         <h3 className="font-bold text-sm mb-1">
-          Install WanderList
+          Install WeTravel
         </h3>
         <p className="text-xs text-sand-400">
           {isIOS 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <title>WeTravel</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6"/>
+      <stop offset="100%" style="stop-color:#015a9f"/>
+    </linearGradient>
+  </defs>
+  <circle cx="16" cy="16" r="15" fill="url(#bg)"/>
+  <!-- Simplified airplane -->
+  <g transform="translate(16, 14) rotate(-30) scale(0.35)">
+    <path d="M -20 60 L -20 20 L -80 -40 L -80 -55 L -20 -10 L -20 -60 L -45 -80 L -45 -95 L -10 -75 L 0 -80 L 10 -75 L 45 -95 L 45 -80 L 20 -60 L 20 -10 L 80 -55 L 80 -40 L 20 20 L 20 60 L 0 75 Z" fill="#eb6b42"/>
+  </g>
+  <!-- W path -->
+  <path d="M 8 24 L 11 19 L 14 22 L 16 17 L 18 22 L 21 19 L 24 24" 
+        fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,27 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#015a9f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="grad2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#eb6b42;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#d84f28;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Background circle -->
+  <circle cx="256" cy="256" r="240" fill="url(#grad1)"/>
+  <!-- Globe lines -->
+  <ellipse cx="256" cy="256" rx="160" ry="160" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="8"/>
+  <ellipse cx="256" cy="256" rx="80" ry="160" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="8"/>
+  <line x1="96" y1="256" x2="416" y2="256" stroke="rgba(255,255,255,0.2)" stroke-width="8"/>
+  <path d="M 120 180 Q 256 220 392 180" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="8"/>
+  <path d="M 120 332 Q 256 292 392 332" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="8"/>
+  <!-- Airplane -->
+  <g transform="translate(256, 256) rotate(-30)">
+    <path d="M -20 60 L -20 20 L -80 -40 L -80 -55 L -20 -10 L -20 -60 L -45 -80 L -45 -95 L -10 -75 L 0 -80 L 10 -75 L 45 -95 L 45 -80 L 20 -60 L 20 -10 L 80 -55 L 80 -40 L 20 20 L 20 60 L 0 75 Z" fill="url(#grad2)"/>
+  </g>
+  <!-- W letter hint with travel path -->
+  <path d="M 140 380 L 180 320 L 220 360 L 256 300 L 292 360 L 332 320 L 372 380" 
+        fill="none" stroke="white" stroke-width="16" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,10 +21,10 @@ export default defineConfig(({ mode }) => {
         react(),
         VitePWA({
           registerType: 'prompt',
-          includeAssets: ['icon.svg'],
+          includeAssets: ['icon.svg', 'favicon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',


### PR DESCRIPTION
## Summary

- Renamed the app from **WanderList** to **WeTravel** across all branding locations
- Added a new **favicon.svg** for browser tabs
- Updated **PWA icon** (icon.svg) with a travel-themed design featuring a globe, airplane, and stylized "W"
- Updated PWA manifest with new name and short_name

## Changes Made

| File | Change |
|------|--------|
| `index.html` | Updated `<title>` to "WeTravel", added favicon link |
| `vite.config.ts` | Updated PWA manifest `name` and `short_name` to "WeTravel" |
| `App.tsx` | Updated header branding text |
| `components/InstallPrompt.tsx` | Updated install prompt text |
| `public/icon.svg` | New travel-themed PWA icon design |
| `public/favicon.svg` | New favicon for browser tabs |

## Visual Preview

The new icon features:
- Ocean blue gradient background (matching the app's color palette)
- White globe grid lines
- Terracotta-colored airplane
- Stylized "W" travel path at the bottom

Closes #4