### PR TITLE
feat: rename app to WeTravel with new favicon and PWA icons

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -101,7 +101,7 @@ const App: React.FC = () => {
           ) : (
             <div className="flex items-center gap-2 animate-in fade-in duration-300">
               <div className="w-8 h-8 bg-terracotta-500 rounded-xl flex items-center justify-center shadow-lg shadow-terracotta-500/20"><Sparkles className="w-5 h-5 text-white" /></div>
-              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WanderList</h1>
+              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WeTravel</h1>
             </div>
           )}
           <ThemeToggle />

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -66,7 +66,7 @@ const InstallPrompt: React.FC = () => {
     <div className="fixed bottom-4 left-4 z-[100] bg-white text-ocean-900 p-4 rounded-xl shadow-2xl border border-sand-200 flex items-center gap-4 animate-in slide-in-from-bottom duration-300 max-w-sm">
       <div className="flex-1">
         <h3 className="font-bold text-sm mb-1">
-          Install WanderList
+          Install WeTravel
         </h3>
         <p className="text-xs text-sand-400">
           {isIOS 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <title>WeTravel</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="apple-touch-icon" href="/icon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0070c4"/>
+      <stop offset="100%" style="stop-color:#015a9f"/>
+    </linearGradient>
+  </defs>
+  <circle cx="16" cy="16" r="16" fill="url(#bg)"/>
+  <path d="M7 9 L10 22 L16 14 L22 22 L25 9" 
+        fill="none" 
+        stroke="#ffffff" 
+        stroke-width="3" 
+        stroke-linecap="round" 
+        stroke-linejoin="round"/>
+</svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0070c4"/>
+      <stop offset="100%" style="stop-color:#015a9f"/>
+    </linearGradient>
+    <linearGradient id="planeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffffff"/>
+      <stop offset="100%" style="stop-color:#f0f7ff"/>
+    </linearGradient>
+  </defs>
+  <!-- Background circle -->
+  <circle cx="256" cy="256" r="256" fill="url(#bgGrad)"/>
+  <!-- Globe lines for travel theme -->
+  <ellipse cx="256" cy="256" rx="140" ry="140" fill="none" stroke="#ffffff" stroke-width="8" stroke-opacity="0.2"/>
+  <ellipse cx="256" cy="256" rx="140" ry="60" fill="none" stroke="#ffffff" stroke-width="6" stroke-opacity="0.15"/>
+  <line x1="116" y1="256" x2="396" y2="256" stroke="#ffffff" stroke-width="6" stroke-opacity="0.15"/>
+  <line x1="256" y1="116" x2="256" y2="396" stroke="#ffffff" stroke-width="6" stroke-opacity="0.15"/>
+  <!-- Stylized W for WeTravel -->
+  <path d="M140 170 L180 340 L256 240 L332 340 L372 170" 
+        fill="none" 
+        stroke="url(#planeGrad)" 
+        stroke-width="36" 
+        stroke-linecap="round" 
+        stroke-linejoin="round"/>
+  <!-- Small airplane accent -->
+  <g transform="translate(340, 140) rotate(45)">
+    <path d="M0 0 L30 10 L30 14 L8 12 L6 28 L2 28 L4 12 L-18 14 L-18 10 Z" 
+          fill="#eb6b42"/>
+  </g>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,10 +21,10 @@ export default defineConfig(({ mode }) => {
         react(),
         VitePWA({
           registerType: 'prompt',
-          includeAssets: ['icon.svg'],
+          includeAssets: ['icon.svg', 'favicon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',


### PR DESCRIPTION
## Summary

Closes #4

- **Renamed app** from WanderList to **WeTravel** across all files
- **Created new branded SVG icon** with travel theme (ocean blue gradient globe + stylized "W" + airplane accent)
- **Added favicon.svg** for browser tab (optimized smaller version)
- **Updated PWA manifest** with new app name

## Changes Made

| File | Change |
|------|--------|
| `App.tsx` | Header title: WanderList → WeTravel |
| `index.html` | Page title + favicon links |
| `components/InstallPrompt.tsx` | Install prompt text |
| `vite.config.ts` | PWA manifest name + short_name |
| `public/icon.svg` | New branded 512x512 app icon |
| `public/favicon.svg` | New 32x32 favicon |

## Icon Design

The new icon features:
- Ocean blue gradient background (#0070c4 → #015a9f) matching the app's color palette
- Stylized "W" for WeTravel in white
- Subtle globe lines for travel theme
- Small terracotta (#eb6b42) airplane accent

## Testing

- ✅ Build passes successfully
- ✅ PWA manifest correctly generated with new name
- ✅ Icons properly referenced in manifest