### PR TITLE
Rebrand app to WeTravel with favicon and PWA icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <title>WeTravel</title>
+    <link rel="icon" type="image/svg+xml" href="/icon.svg">
+    <link rel="apple-touch-icon" href="/icon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "Trip Planner",
+  "name": "WeTravel",
   "description": "A comprehensive travel companion app to organize trips, view flight itineraries, discover new places, and visualize your journey on an interactive timeline and map.",
   "requestFramePermissions": [
     "geolocation"

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,35 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#015a9f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#eb6b42;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#d84f28;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Rounded square background -->
+  <rect x="16" y="16" width="480" height="480" rx="96" ry="96" fill="url(#bgGrad)"/>
+  <!-- Globe/Earth circle -->
+  <circle cx="256" cy="240" r="140" fill="none" stroke="#ffffff" stroke-width="16" opacity="0.9"/>
+  <!-- Globe latitude lines -->
+  <ellipse cx="256" cy="240" rx="140" ry="50" fill="none" stroke="#ffffff" stroke-width="8" opacity="0.6"/>
+  <ellipse cx="256" cy="240" rx="140" ry="100" fill="none" stroke="#ffffff" stroke-width="8" opacity="0.6"/>
+  <!-- Globe longitude line -->
+  <line x1="256" y1="100" x2="256" y2="380" stroke="#ffffff" stroke-width="8" opacity="0.6"/>
+  <!-- Airplane -->
+  <g transform="translate(256, 240) rotate(-30)">
+    <path d="M0,-60 L20,-20 L80,-10 L80,0 L20,15 L10,60 L0,50 L-10,60 L-20,15 L-80,0 L-80,-10 L-20,-20 Z" 
+          fill="url(#accentGrad)" stroke="#ffffff" stroke-width="4"/>
+  </g>
+  <!-- Location pin -->
+  <g transform="translate(340, 160)">
+    <path d="M0,0 C-20,0 -36,16 -36,36 C-36,63 0,90 0,90 C0,90 36,63 36,36 C36,16 20,0 0,0 Z" 
+          fill="url(#accentGrad)" stroke="#ffffff" stroke-width="4"/>
+    <circle cx="0" cy="36" r="14" fill="#ffffff"/>
+  </g>
+  <!-- WeTravel text at bottom -->
+  <text x="256" y="445" font-family="Arial, sans-serif" font-size="56" font-weight="bold" 
+        fill="#ffffff" text-anchor="middle" opacity="0.95">WeTravel</text>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,8 +23,8 @@ export default defineConfig(({ mode }) => {
           registerType: 'prompt',
           includeAssets: ['icon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',


### PR DESCRIPTION
## Summary
- Rebrands app from WanderList/Trip Planner to **WeTravel**
- Adds favicon link in index.html for browser tab icon
- Creates new branded SVG icon with travel-themed design (globe, airplane, location pin)
- Updates PWA manifest with new name and short_name

## Changes
| File | Change |
|------|--------|
| `index.html` | Updated title to WeTravel, added favicon/apple-touch-icon links |
| `vite.config.ts` | Updated PWA manifest name and short_name |
| `metadata.json` | Updated app name |
| `public/icon.svg` | New branded icon using ocean/terracotta color scheme |

## Testing
- [x] Build passes successfully
- [x] PWA manifest generates correctly with WeTravel branding
- [x] Icon uses project color palette (ocean blue, terracotta accents)

Closes #4