### PR TITLE
feat: rename app to WeTravel and add favicon/PWA icons

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -101,7 +101,7 @@ const App: React.FC = () => {
           ) : (
             <div className="flex items-center gap-2 animate-in fade-in duration-300">
               <div className="w-8 h-8 bg-terracotta-500 rounded-xl flex items-center justify-center shadow-lg shadow-terracotta-500/20"><Sparkles className="w-5 h-5 text-white" /></div>
-              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WanderList</h1>
+              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WeTravel</h1>
             </div>
           )}
           <ThemeToggle />

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -66,7 +66,7 @@ const InstallPrompt: React.FC = () => {
     <div className="fixed bottom-4 left-4 z-[100] bg-white text-ocean-900 p-4 rounded-xl shadow-2xl border border-sand-200 flex items-center gap-4 animate-in slide-in-from-bottom duration-300 max-w-sm">
       <div className="flex-1">
         <h3 className="font-bold text-sm mb-1">
-          Install WanderList
+          Install WeTravel
         </h3>
         <p className="text-xs text-sand-400">
           {isIOS 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <title>WeTravel</title>
+    <link rel="icon" type="image/svg+xml" href="/icon.svg">
+    <link rel="apple-touch-icon" href="/icon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "Trip Planner",
+  "name": "WeTravel",
   "description": "A comprehensive travel companion app to organize trips, view flight itineraries, discover new places, and visualize your journey on an interactive timeline and map.",
   "requestFramePermissions": [
     "geolocation"

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,39 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#eb6b42"/>
+      <stop offset="100%" style="stop-color:#d84f28"/>
+    </linearGradient>
+    <linearGradient id="planeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffffff"/>
+      <stop offset="100%" style="stop-color:#f0f7ff"/>
+    </linearGradient>
+  </defs>
+  
+  <!-- Background circle with gradient -->
+  <circle cx="256" cy="256" r="240" fill="url(#bgGradient)"/>
+  
+  <!-- Subtle inner shadow -->
+  <circle cx="256" cy="256" r="220" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="2"/>
+  
+  <!-- Stylized airplane -->
+  <g transform="translate(256, 256) rotate(-30) translate(-256, -256)">
+    <path d="M380 200 L420 180 L430 185 L400 220 L380 215 Z" fill="url(#planeGradient)"/>
+    <path d="M120 280 L380 200 L400 220 L180 340 L160 330 Z" fill="url(#planeGradient)"/>
+    <path d="M180 340 L200 380 L190 385 L160 350 Z" fill="url(#planeGradient)"/>
+    <path d="M120 280 L100 260 L110 255 L135 275 Z" fill="url(#planeGradient)"/>
+    <!-- Wing -->
+    <path d="M200 260 L280 320 L260 340 L170 290 Z" fill="rgba(255,255,255,0.85)"/>
+    <!-- Tail -->
+    <path d="M140 300 L165 310 L175 340 L150 330 Z" fill="rgba(255,255,255,0.9)"/>
+  </g>
+  
+  <!-- Flight path dotted arc -->
+  <path d="M130 350 Q180 200 350 150" fill="none" stroke="rgba(255,255,255,0.4)" stroke-width="3" stroke-dasharray="8,8" stroke-linecap="round"/>
+  
+  <!-- Small location pin -->
+  <g transform="translate(355, 140)">
+    <circle cx="0" cy="0" r="12" fill="#ffffff"/>
+    <circle cx="0" cy="0" r="5" fill="#eb6b42"/>
+  </g>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,9 +23,9 @@ export default defineConfig(({ mode }) => {
           registerType: 'prompt',
           includeAssets: ['icon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
-            description: 'AI-powered travel planner for your next adventure',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
+            description: 'Plan and organize your trips with AI-powered suggestions',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',
             display: 'standalone',


### PR DESCRIPTION
## Summary

Closes #4

- **App Rename**: Updated app name from WanderList to WeTravel across all UI and config locations
- **Favicon**: Added SVG favicon link in `index.html`  
- **PWA Icon**: Created travel-themed icon featuring an airplane and location pin with terracotta gradient

## Changes

| File | Change |
|------|--------|
| `index.html` | Title → WeTravel, favicon link added |
| `vite.config.ts` | PWA manifest name/short_name → WeTravel |
| `App.tsx` | Header logo text → WeTravel |
| `components/InstallPrompt.tsx` | Install prompt text → WeTravel |
| `metadata.json` | App metadata name → WeTravel |
| `public/icon.svg` | New travel-themed icon design |

## Preview

The new icon features:
- Terracotta gradient background (matching app accent color)
- Stylized airplane
- Location pin destination marker
- Flight path arc