### PR TITLE
feat: rename app to WeTravel with new favicon and PWA icon

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -101,7 +101,7 @@ const App: React.FC = () => {
           ) : (
             <div className="flex items-center gap-2 animate-in fade-in duration-300">
               <div className="w-8 h-8 bg-terracotta-500 rounded-xl flex items-center justify-center shadow-lg shadow-terracotta-500/20"><Sparkles className="w-5 h-5 text-white" /></div>
-              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WanderList</h1>
+              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WeTravel</h1>
             </div>
           )}
           <ThemeToggle />

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -66,7 +66,7 @@ const InstallPrompt: React.FC = () => {
     <div className="fixed bottom-4 left-4 z-[100] bg-white text-ocean-900 p-4 rounded-xl shadow-2xl border border-sand-200 flex items-center gap-4 animate-in slide-in-from-bottom duration-300 max-w-sm">
       <div className="flex-1">
         <h3 className="font-bold text-sm mb-1">
-          Install WanderList
+          Install WeTravel
         </h3>
         <p className="text-xs text-sand-400">
           {isIOS 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <title>WeTravel</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#015a9f;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Background circle -->
+  <circle cx="16" cy="16" r="15" fill="url(#bgGrad)"/>
+  <!-- Simplified airplane icon -->
+  <g transform="translate(16, 16) rotate(-45) translate(-16, -16)">
+    <path fill="#ffffff" d="M26 12l-6-2-4-8h-2l2 8H10l-2-3H6l2 5-2 5h2l2-3h6l-2 8h2l4-8 6-2z" transform="translate(1, 3)"/>
+  </g>
+</svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#015a9f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="planeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffffff;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#f0f7ff;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Background circle -->
+  <circle cx="256" cy="256" r="240" fill="url(#bgGrad)"/>
+  <!-- Airplane icon -->
+  <g transform="translate(256, 256) rotate(-45) translate(-256, -256)">
+    <path fill="url(#planeGrad)" d="M416 192l-96-32-64-128h-32l32 128H160l-32-48H96l32 80-32 80h32l32-48h96l-32 128h32l64-128 96-32z" transform="translate(16, 48)"/>
+  </g>
+  <!-- Globe lines for travel theme -->
+  <ellipse cx="256" cy="256" rx="160" ry="160" fill="none" stroke="#ffffff" stroke-width="3" stroke-opacity="0.2"/>
+  <ellipse cx="256" cy="256" rx="80" ry="160" fill="none" stroke="#ffffff" stroke-width="2" stroke-opacity="0.15"/>
+  <line x1="96" y1="256" x2="416" y2="256" stroke="#ffffff" stroke-width="2" stroke-opacity="0.15"/>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,10 +21,10 @@ export default defineConfig(({ mode }) => {
         react(),
         VitePWA({
           registerType: 'prompt',
-          includeAssets: ['icon.svg'],
+          includeAssets: ['icon.svg', 'favicon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel - AI Trip Planner',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',


### PR DESCRIPTION
## Summary

Implements issue #4: Change the app name to WeTravel with new favicon and PWA icons.

## Changes

- **App Name**: Renamed from "WanderList" to "WeTravel" across all files:
  - `index.html`: Updated `<title>` tag
  - `vite.config.ts`: Updated PWA manifest `name` and `short_name`
  - `App.tsx`: Updated header branding text
  - `components/InstallPrompt.tsx`: Updated install prompt text

- **Icons**: Created new travel-themed icons:
  - `public/icon.svg`: PWA icon with airplane on ocean blue gradient background (for installed app)
  - `public/favicon.svg`: Matching favicon for browser tabs

## Visual Preview

The new icon features:
- Ocean blue gradient background (matching the app's color palette)
- White airplane icon rotated for dynamic appearance
- Subtle globe lines for travel theme

## Closes

Closes #4