### PR TITLE
feat: rename app to WeTravel with new favicon and PWA icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <title>WeTravel</title>
+    <link rel="icon" type="image/svg+xml" href="/icon.svg">
+    <link rel="apple-touch-icon" href="/icon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "Trip Planner",
+  "name": "WeTravel",
   "description": "A comprehensive travel companion app to organize trips, view flight itineraries, discover new places, and visualize your journey on an interactive timeline and map.",
   "requestFramePermissions": [
     "geolocation"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "trip-planner",
+  "name": "wetravel",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "trip-planner",
+      "name": "wetravel",
       "version": "0.0.0",
       "dependencies": {
         "@google/genai": "^1.34.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "trip-planner",
+  "name": "wetravel",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,43 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="globeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#36aaf5"/>
+      <stop offset="100%" style="stop-color:#015a9f"/>
+    </linearGradient>
+    <linearGradient id="planeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f48c6a"/>
+      <stop offset="100%" style="stop-color:#eb6b42"/>
+    </linearGradient>
+  </defs>
+  
+  <!-- Background circle -->
+  <circle cx="256" cy="256" r="240" fill="url(#globeGradient)"/>
+  
+  <!-- Globe lines - horizontal -->
+  <ellipse cx="256" cy="256" rx="200" ry="200" fill="none" stroke="rgba(255,255,255,0.3)" stroke-width="3"/>
+  <ellipse cx="256" cy="256" rx="200" ry="80" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="2"/>
+  <ellipse cx="256" cy="256" rx="200" ry="140" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="2"/>
+  
+  <!-- Globe lines - vertical -->
+  <ellipse cx="256" cy="256" rx="80" ry="200" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="2"/>
+  <ellipse cx="256" cy="256" rx="140" ry="200" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="2"/>
+  
+  <!-- Meridian line -->
+  <line x1="256" y1="56" x2="256" y2="456" stroke="rgba(255,255,255,0.3)" stroke-width="2"/>
+  <line x1="56" y1="256" x2="456" y2="256" stroke="rgba(255,255,255,0.3)" stroke-width="2"/>
+  
+  <!-- Airplane -->
+  <g transform="translate(256, 256) rotate(-30)">
+    <path d="M-80,0 L-40,-15 L60,-15 L100,-60 L115,-60 L90,-15 L120,-15 L130,-30 L145,-30 L135,-5 L145,5 L135,30 L130,30 L120,15 L90,15 L115,60 L100,60 L60,15 L-40,15 L-80,0 Z" 
+          fill="url(#planeGradient)" 
+          stroke="white" 
+          stroke-width="3"/>
+    <!-- Plane windows -->
+    <circle cx="20" cy="0" r="6" fill="white" opacity="0.9"/>
+    <circle cx="40" cy="0" r="6" fill="white" opacity="0.9"/>
+    <circle cx="60" cy="0" r="6" fill="white" opacity="0.9"/>
+  </g>
+  
+  <!-- Subtle inner glow -->
+  <circle cx="256" cy="256" r="235" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="10"/>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,10 +21,10 @@ export default defineConfig(({ mode }) => {
         react(),
         VitePWA({
           registerType: 'prompt',
-          includeAssets: ['icon.svg'],
+          includeAssets: ['icon.svg', 'favicon.ico', 'apple-touch-icon.png'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',
@@ -36,9 +36,15 @@ export default defineConfig(({ mode }) => {
             icons: [
               {
                 src: 'icon.svg',
-                sizes: '192x192 512x512',
+                sizes: 'any',
                 type: 'image/svg+xml',
-                purpose: 'any maskable'
+                purpose: 'any'
+              },
+              {
+                src: 'icon.svg',
+                sizes: '512x512',
+                type: 'image/svg+xml',
+                purpose: 'maskable'
               }
             ]
           },


### PR DESCRIPTION
## Summary

- Renamed app from "WanderList AI / Trip Planner" to **WeTravel** across all locations
- Created new travel-themed favicon/icon featuring a globe with airplane
- Updated PWA manifest with proper icon configuration

## Changes

- **index.html**: Updated title to "WeTravel", added favicon and apple-touch-icon links
- **vite.config.ts**: Updated PWA manifest name/short_name to "WeTravel", improved icon configuration
- **metadata.json**: Updated app name to "WeTravel"
- **package.json**: Updated package name to "wetravel"
- **public/icon.svg**: New travel-themed icon with globe and airplane design using ocean blue gradient with terracotta airplane

## Icon Preview

The new icon features:
- Blue gradient globe (matching the app's ocean color palette)
- Terracotta-colored airplane overlay (matching the app's accent color)
- Globe meridian lines for travel/world theme
- Clean, modern, PWA-ready SVG format

Closes #4