### PR TITLE
feat: Rename app to WeTravel with new icon and favicon

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -101,7 +101,7 @@ const App: React.FC = () => {
           ) : (
             <div className="flex items-center gap-2 animate-in fade-in duration-300">
               <div className="w-8 h-8 bg-terracotta-500 rounded-xl flex items-center justify-center shadow-lg shadow-terracotta-500/20"><Sparkles className="w-5 h-5 text-white" /></div>
-              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WanderList</h1>
+              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WeTravel</h1>
             </div>
           )}
           <ThemeToggle />

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -66,7 +66,7 @@ const InstallPrompt: React.FC = () => {
     <div className="fixed bottom-4 left-4 z-[100] bg-white text-ocean-900 p-4 rounded-xl shadow-2xl border border-sand-200 flex items-center gap-4 animate-in slide-in-from-bottom duration-300 max-w-sm">
       <div className="flex-1">
         <h3 className="font-bold text-sm mb-1">
-          Install WanderList
+          Install WeTravel
         </h3>
         <p className="text-xs text-sand-400">
           {isIOS 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <title>WeTravel</title>
+    <link rel="icon" type="image/svg+xml" href="/icon.svg">
+    <link rel="apple-touch-icon" href="/icon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "Trip Planner",
+  "name": "WeTravel",
   "description": "A comprehensive travel companion app to organize trips, view flight itineraries, discover new places, and visualize your journey on an interactive timeline and map.",
   "requestFramePermissions": [
     "geolocation"

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,33 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#015a9f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="planeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffffff;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#f0f7ff;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Background circle -->
+  <circle cx="256" cy="256" r="240" fill="url(#bgGrad)"/>
+  <!-- Decorative ring -->
+  <circle cx="256" cy="256" r="200" fill="none" stroke="#ffffff" stroke-width="2" stroke-opacity="0.2"/>
+  <!-- Globe lines for travel theme -->
+  <ellipse cx="256" cy="256" rx="140" ry="140" fill="none" stroke="#ffffff" stroke-width="2" stroke-opacity="0.15"/>
+  <ellipse cx="256" cy="256" rx="70" ry="140" fill="none" stroke="#ffffff" stroke-width="2" stroke-opacity="0.15"/>
+  <path d="M116 256 H396" stroke="#ffffff" stroke-width="2" stroke-opacity="0.15"/>
+  <!-- Airplane icon -->
+  <g transform="translate(256, 256) rotate(-45)">
+    <path d="M-20,-80 L20,-80 L20,-20 L80,40 L80,60 L20,20 L20,60 L40,80 L40,95 L0,75 L-40,95 L-40,80 L-20,60 L-20,20 L-80,60 L-80,40 L-20,-20 Z" 
+          fill="url(#planeGrad)" 
+          stroke="#ffffff" 
+          stroke-width="2"/>
+  </g>
+  <!-- Location pin accent -->
+  <g transform="translate(340, 340)">
+    <path d="M0,-35 C15,-35 25,-25 25,-12 C25,5 0,35 0,35 C0,35 -25,5 -25,-12 C-25,-25 -15,-35 0,-35 Z" 
+          fill="#eb6b42"/>
+    <circle cx="0" cy="-12" r="8" fill="#ffffff"/>
+  </g>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,8 +23,8 @@ export default defineConfig(({ mode }) => {
           registerType: 'prompt',
           includeAssets: ['icon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',


### PR DESCRIPTION
## Summary

Closes #4

- **Renamed app** from "WanderList" to "WeTravel" across all files:
  - `index.html` title tag
  - `App.tsx` header component
  - `vite.config.ts` PWA manifest (name and short_name)
  - `components/InstallPrompt.tsx` install button text
  - `metadata.json`

- **Added new WeTravel icon** (`public/icon.svg`):
  - Modern travel-themed design with airplane and location pin
  - Ocean blue gradient background matching app color scheme
  - Decorative globe lines for travel theme

- **Added favicon support**:
  - Added `<link rel="icon">` pointing to the SVG icon
  - Added `<link rel="apple-touch-icon">` for iOS home screen

## Testing

- [x] Build passes (`npm run build`)
- [x] All name references updated
- [x] Icon displays correctly for PWA