### PR TITLE
feat: Rename app to WeTravel with new favicon and PWA icons

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -101,7 +101,7 @@ const App: React.FC = () => {
           ) : (
             <div className="flex items-center gap-2 animate-in fade-in duration-300">
               <div className="w-8 h-8 bg-terracotta-500 rounded-xl flex items-center justify-center shadow-lg shadow-terracotta-500/20"><Sparkles className="w-5 h-5 text-white" /></div>
-              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WanderList</h1>
+              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WeTravel</h1>
             </div>
           )}
           <ThemeToggle />

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -66,7 +66,7 @@ const InstallPrompt: React.FC = () => {
     <div className="fixed bottom-4 left-4 z-[100] bg-white text-ocean-900 p-4 rounded-xl shadow-2xl border border-sand-200 flex items-center gap-4 animate-in slide-in-from-bottom duration-300 max-w-sm">
       <div className="flex-1">
         <h3 className="font-bold text-sm mb-1">
-          Install WanderList
+          Install WeTravel
         </h3>
         <p className="text-xs text-sand-400">
           {isIOS 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <title>WeTravel</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="apple-touch-icon" href="/icon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "Trip Planner",
+  "name": "WeTravel",
   "description": "A comprehensive travel companion app to organize trips, view flight itineraries, discover new places, and visualize your journey on an interactive timeline and map.",
   "requestFramePermissions": [
     "geolocation"

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="globeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#36aaf5;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#0070c4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="planeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#eb6b42;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#d84f28;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background circle -->
+  <circle cx="16" cy="16" r="15" fill="url(#globeGrad)"/>
+  
+  <!-- Simple globe lines -->
+  <ellipse cx="16" cy="16" rx="12" ry="4" fill="none" stroke="#fff" stroke-width="1" opacity="0.4"/>
+  <ellipse cx="16" cy="16" rx="4" ry="12" fill="none" stroke="#fff" stroke-width="1" opacity="0.4"/>
+  
+  <!-- Simplified airplane -->
+  <g transform="translate(16, 11) rotate(45) scale(0.12)">
+    <path d="M0,-80 L20,-40 L20,-20 L80,20 L80,40 L20,20 L20,60 L40,80 L40,100 L0,80 L-40,100 L-40,80 L-20,60 L-20,20 L-80,40 L-80,20 L-20,-20 L-20,-40 Z" 
+          fill="url(#planeGrad)" 
+          stroke="#fff" 
+          stroke-width="8"/>
+  </g>
+</svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,40 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="globeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#36aaf5;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#0070c4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="planeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#eb6b42;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#d84f28;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background circle -->
+  <circle cx="256" cy="256" r="240" fill="url(#globeGrad)"/>
+  
+  <!-- Globe latitude lines -->
+  <ellipse cx="256" cy="256" rx="200" ry="70" fill="none" stroke="#fff" stroke-width="8" opacity="0.3"/>
+  <ellipse cx="256" cy="256" rx="200" ry="140" fill="none" stroke="#fff" stroke-width="8" opacity="0.3"/>
+  
+  <!-- Globe longitude lines -->
+  <ellipse cx="256" cy="256" rx="70" ry="200" fill="none" stroke="#fff" stroke-width="8" opacity="0.3"/>
+  <line x1="56" y1="256" x2="456" y2="256" stroke="#fff" stroke-width="8" opacity="0.3"/>
+  <line x1="256" y1="56" x2="256" y2="456" stroke="#fff" stroke-width="8" opacity="0.3"/>
+  
+  <!-- Airplane -->
+  <g transform="translate(256, 160) rotate(45)">
+    <path d="M0,-80 L20,-40 L20,-20 L80,20 L80,40 L20,20 L20,60 L40,80 L40,100 L0,80 L-40,100 L-40,80 L-20,60 L-20,20 L-80,40 L-80,20 L-20,-20 L-20,-40 Z" 
+          fill="url(#planeGrad)" 
+          stroke="#fff" 
+          stroke-width="4"/>
+  </g>
+  
+  <!-- Flight path arc -->
+  <path d="M100,350 Q256,150 420,320" 
+        fill="none" 
+        stroke="#fff" 
+        stroke-width="6" 
+        stroke-dasharray="20,10" 
+        opacity="0.6"/>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,10 +21,10 @@ export default defineConfig(({ mode }) => {
         react(),
         VitePWA({
           registerType: 'prompt',
-          includeAssets: ['icon.svg'],
+          includeAssets: ['icon.svg', 'favicon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',


### PR DESCRIPTION
## Summary

- Changed app name from **WanderList** to **WeTravel** across all files
- Created new travel-themed SVG icons with globe and airplane design
- Added favicon.svg for browser tab display
- Updated PWA manifest configuration

## Changes Made

| File | Change |
|------|--------|
| `index.html` | Updated title to "WeTravel", added favicon/apple-touch-icon links |
| `App.tsx` | Changed header branding from WanderList to WeTravel |
| `vite.config.ts` | Updated PWA manifest name/short_name, added favicon to assets |
| `components/InstallPrompt.tsx` | Changed install prompt text |
| `metadata.json` | Updated app name |
| `public/icon.svg` | New travel-themed icon (globe with airplane and flight path) |
| `public/favicon.svg` | New favicon optimized for small sizes |

## Visual Changes

The new icon features:
- Ocean blue globe with latitude/longitude lines
- Terracotta orange airplane in flight
- Dashed flight path arc
- White accents for contrast

Closes #4