### PR TITLE
feat: Rename app to WeTravel and add favicon/icons

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -101,7 +101,7 @@ const App: React.FC = () => {
           ) : (
             <div className="flex items-center gap-2 animate-in fade-in duration-300">
               <div className="w-8 h-8 bg-terracotta-500 rounded-xl flex items-center justify-center shadow-lg shadow-terracotta-500/20"><Sparkles className="w-5 h-5 text-white" /></div>
-              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WanderList</h1>
+              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WeTravel</h1>
             </div>
           )}
           <ThemeToggle />

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -66,7 +66,7 @@ const InstallPrompt: React.FC = () => {
     <div className="fixed bottom-4 left-4 z-[100] bg-white text-ocean-900 p-4 rounded-xl shadow-2xl border border-sand-200 flex items-center gap-4 animate-in slide-in-from-bottom duration-300 max-w-sm">
       <div className="flex-1">
         <h3 className="font-bold text-sm mb-1">
-          Install WanderList
+          Install WeTravel
         </h3>
         <p className="text-xs text-sand-400">
           {isIOS 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <title>WeTravel</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="apple-touch-icon" href="/icon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "Trip Planner",
+  "name": "WeTravel",
   "description": "A comprehensive travel companion app to organize trips, view flight itineraries, discover new places, and visualize your journey on an interactive timeline and map.",
   "requestFramePermissions": [
     "geolocation"

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#015a9f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#eb6b42;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#d84f28;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background rounded square -->
+  <rect x="0" y="0" width="32" height="32" rx="6" fill="url(#bgGrad)"/>
+  
+  <!-- Simple airplane -->
+  <g transform="translate(16, 15) rotate(-30) scale(0.4)">
+    <path d="M-20,-100 L20,-100 L30,-40 L90,-20 L90,10 L30,0 L20,80 L40,100 L40,115 L0,95 L-40,115 L-40,100 L-20,80 L-30,0 L-90,10 L-90,-20 L-30,-40 Z" 
+          fill="white"/>
+  </g>
+  
+  <!-- Small location dot -->
+  <circle cx="24" cy="24" r="5" fill="url(#accentGrad)"/>
+  <circle cx="24" cy="24" r="2" fill="white"/>
+</svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,35 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#015a9f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#eb6b42;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#d84f28;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background circle -->
+  <circle cx="256" cy="256" r="240" fill="url(#bgGradient)"/>
+  
+  <!-- Globe lines (simplified) -->
+  <ellipse cx="256" cy="256" rx="160" ry="160" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="3"/>
+  <ellipse cx="256" cy="256" rx="80" ry="160" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="3"/>
+  <line x1="96" y1="256" x2="416" y2="256" stroke="rgba(255,255,255,0.15)" stroke-width="3"/>
+  <ellipse cx="256" cy="256" rx="160" ry="60" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="3"/>
+  
+  <!-- Airplane icon -->
+  <g transform="translate(256, 256) rotate(-30)">
+    <path d="M-20,-100 L20,-100 L30,-40 L90,-20 L90,10 L30,0 L20,80 L40,100 L40,115 L0,95 L-40,115 L-40,100 L-20,80 L-30,0 L-90,10 L-90,-20 L-30,-40 Z" 
+          fill="white" 
+          stroke="none"/>
+  </g>
+  
+  <!-- Location pin accent -->
+  <g transform="translate(340, 340)">
+    <path d="M0,-45 C-25,-45 -45,-25 -45,0 C-45,25 0,55 0,55 C0,55 45,25 45,0 C45,-25 25,-45 0,-45 Z" 
+          fill="url(#accentGradient)"/>
+    <circle cx="0" cy="0" r="15" fill="white"/>
+  </g>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,10 +21,10 @@ export default defineConfig(({ mode }) => {
         react(),
         VitePWA({
           registerType: 'prompt',
-          includeAssets: ['icon.svg'],
+          includeAssets: ['icon.svg', 'favicon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',


### PR DESCRIPTION
## Summary

- Rename app from **WanderList** to **WeTravel** across all UI and config files
- Create new travel-themed **icon.svg** featuring airplane with globe and location pin
- Add **favicon.svg** for browser tabs
- Update PWA manifest with new app name

## Changes Made

| File | Change |
|------|--------|
| `index.html` | Title → "WeTravel", added favicon link |
| `vite.config.ts` | PWA name/short_name → "WeTravel" |
| `App.tsx` | Header text → "WeTravel" |
| `InstallPrompt.tsx` | Install prompt → "Install WeTravel" |
| `metadata.json` | App name → "WeTravel" |
| `public/icon.svg` | New travel-themed icon (airplane + globe + location pin) |
| `public/favicon.svg` | New favicon for browser tabs |

## Testing

- [x] Build passes successfully
- [x] PWA manifest updated correctly

Closes #4