### PR TITLE
Rename app to WeTravel with new favicon and PWA icon

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -101,7 +101,7 @@ const App: React.FC = () => {
           ) : (
             <div className="flex items-center gap-2 animate-in fade-in duration-300">
               <div className="w-8 h-8 bg-terracotta-500 rounded-xl flex items-center justify-center shadow-lg shadow-terracotta-500/20"><Sparkles className="w-5 h-5 text-white" /></div>
-              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WanderList</h1>
+              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WeTravel</h1>
             </div>
           )}
           <ThemeToggle />

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -66,7 +66,7 @@ const InstallPrompt: React.FC = () => {
     <div className="fixed bottom-4 left-4 z-[100] bg-white text-ocean-900 p-4 rounded-xl shadow-2xl border border-sand-200 flex items-center gap-4 animate-in slide-in-from-bottom duration-300 max-w-sm">
       <div className="flex-1">
         <h3 className="font-bold text-sm mb-1">
-          Install WanderList
+          Install WeTravel
         </h3>
         <p className="text-xs text-sand-400">
           {isIOS 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <link rel="icon" type="image/svg+xml" href="/icon.svg">
+    <link rel="apple-touch-icon" href="/icon.svg">
+    <title>WeTravel</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "Trip Planner",
+  "name": "WeTravel",
   "description": "A comprehensive travel companion app to organize trips, view flight itineraries, discover new places, and visualize your journey on an interactive timeline and map.",
   "requestFramePermissions": [
     "geolocation"

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6"/>
+      <stop offset="100%" style="stop-color:#064c83"/>
+    </linearGradient>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#eb6b42"/>
+      <stop offset="100%" style="stop-color:#d84f28"/>
+    </linearGradient>
+  </defs>
+  <!-- Background circle -->
+  <circle cx="256" cy="256" r="240" fill="url(#bgGrad)"/>
+  <!-- Globe lines -->
+  <ellipse cx="256" cy="256" rx="160" ry="160" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="3"/>
+  <ellipse cx="256" cy="256" rx="80" ry="160" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="3"/>
+  <ellipse cx="256" cy="256" rx="160" ry="80" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="3"/>
+  <line x1="96" y1="256" x2="416" y2="256" stroke="rgba(255,255,255,0.2)" stroke-width="3"/>
+  <line x1="256" y1="96" x2="256" y2="416" stroke="rgba(255,255,255,0.2)" stroke-width="3"/>
+  <!-- Airplane -->
+  <g transform="translate(256, 256) rotate(-30)">
+    <path d="M-20,-80 L20,-80 L40,0 L100,20 L100,40 L40,30 L30,80 L50,100 L50,115 L20,100 L0,115 L-20,100 L-50,115 L-50,100 L-30,80 L-40,30 L-100,40 L-100,20 L-40,0 Z" fill="white"/>
+  </g>
+  <!-- Location pin accent -->
+  <g transform="translate(340, 340)">
+    <path d="M0,-50 C22,-50 40,-32 40,-10 C40,15 0,50 0,50 C0,50 -40,15 -40,-10 C-40,-32 -22,-50 0,-50 Z" fill="url(#accentGrad)"/>
+    <circle cx="0" cy="-10" r="15" fill="white"/>
+  </g>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,8 +23,8 @@ export default defineConfig(({ mode }) => {
           registerType: 'prompt',
           includeAssets: ['icon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',


### PR DESCRIPTION
## Summary

Closes #4

- Renamed the app from **WanderList** to **WeTravel** across all branding touchpoints
- Created a new travel-themed favicon/icon featuring a globe with airplane and location pin
- Added proper favicon link tags for browser and iOS home screen

## Changes

| File | Change |
|------|--------|
| `index.html` | Updated title to "WeTravel", added favicon and apple-touch-icon links |
| `vite.config.ts` | Updated PWA manifest name and short_name to "WeTravel" |
| `App.tsx` | Updated header branding text |
| `components/InstallPrompt.tsx` | Updated install button text |
| `metadata.json` | Updated name field |
| `public/icon.svg` | New travel-themed SVG icon with blue gradient background, globe lines, airplane, and location pin accent |

## Icon Design

The new icon features:
- Ocean blue gradient background (matching the app's color palette)
- Subtle globe grid lines
- White airplane silhouette
- Terracotta-colored location pin accent

## Verification

- [x] Build passes (`npm run build`)
- [x] PWA manifest correctly generated with new name
- [x] Icon properly copied to dist folder