### PR TITLE
feat: Rebrand app to WeTravel with new icons

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -101,7 +101,7 @@ const App: React.FC = () => {
           ) : (
             <div className="flex items-center gap-2 animate-in fade-in duration-300">
               <div className="w-8 h-8 bg-terracotta-500 rounded-xl flex items-center justify-center shadow-lg shadow-terracotta-500/20"><Sparkles className="w-5 h-5 text-white" /></div>
-              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WanderList</h1>
+              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WeTravel</h1>
             </div>
           )}
           <ThemeToggle />

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -66,7 +66,7 @@ const InstallPrompt: React.FC = () => {
     <div className="fixed bottom-4 left-4 z-[100] bg-white text-ocean-900 p-4 rounded-xl shadow-2xl border border-sand-200 flex items-center gap-4 animate-in slide-in-from-bottom duration-300 max-w-sm">
       <div className="flex-1">
         <h3 className="font-bold text-sm mb-1">
-          Install WanderList
+          Install WeTravel
         </h3>
         <p className="text-xs text-sand-400">
           {isIOS 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="apple-touch-icon" href="/icon.svg">
+    <title>WeTravel</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#015a9f;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Background circle -->
+  <circle cx="16" cy="16" r="15" fill="url(#bgGrad)"/>
+  <!-- Simplified airplane -->
+  <g transform="translate(16, 16) rotate(-45) scale(0.5)">
+    <path d="M-8,-20 L8,-20 L8,0 L20,10 L20,15 L8,8 L8,15 L12,20 L12,25 L0,20 L-12,25 L-12,20 L-8,15 L-8,8 L-20,15 L-20,10 L-8,0 Z" 
+          fill="white"/>
+  </g>
+</svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,3 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#E67E22">
-  <path d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0zm0 464c-114.7 0-208-93.3-208-208S141.3 48 256 48s208 93.3 208 208-93.3 208-208 208zm-24-336h48v128h-48zm0 160h48v48h-48z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0c8ee6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#015a9f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#eb6b42;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#d84f28;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Background circle -->
+  <circle cx="256" cy="256" r="240" fill="url(#bgGradient)"/>
+  <!-- Globe lines for travel theme -->
+  <ellipse cx="256" cy="256" rx="160" ry="160" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="8"/>
+  <ellipse cx="256" cy="256" rx="80" ry="160" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="8"/>
+  <line x1="96" y1="256" x2="416" y2="256" stroke="rgba(255,255,255,0.2)" stroke-width="8"/>
+  <ellipse cx="256" cy="256" rx="160" ry="60" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="8"/>
+  <!-- Airplane icon -->
+  <g transform="translate(256, 256) rotate(-45)">
+    <path d="M-20,-80 L20,-80 L20,0 L80,40 L80,60 L20,30 L20,60 L40,80 L40,100 L0,80 L-40,100 L-40,80 L-20,60 L-20,30 L-80,60 L-80,40 L-20,0 Z" 
+          fill="white" 
+          opacity="0.95"/>
+  </g>
+  <!-- Accent dot for departure -->
+  <circle cx="160" cy="320" r="24" fill="url(#accentGradient)"/>
+  <!-- Route arc -->
+  <path d="M175,305 Q256,200 340,280" fill="none" stroke="url(#accentGradient)" stroke-width="6" stroke-dasharray="12,8" stroke-linecap="round"/>
 </svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,10 +21,10 @@ export default defineConfig(({ mode }) => {
         react(),
         VitePWA({
           registerType: 'prompt',
-          includeAssets: ['icon.svg'],
+          includeAssets: ['icon.svg', 'favicon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',


### PR DESCRIPTION
## Summary

Rebrands the application from "WanderList" to "WeTravel" and adds new favicon and PWA icons.

### Changes

- **App name updated** in all locations:
  - `index.html` (page title)
  - `App.tsx` (header logo text)
  - `InstallPrompt.tsx` (install prompt message)
  - `vite.config.ts` (PWA manifest name and short_name)

- **New favicon** (`public/favicon.svg`):
  - Modern travel-themed design with airplane on blue gradient background
  - Optimized for browser tab display

- **New PWA icon** (`public/icon.svg`):
  - Detailed version with globe lines, route path, and departure marker
  - Ocean blue (#0c8ee6) gradient matching the app's color scheme
  - Terracotta accent for route visualization
  - Works for both standard and maskable PWA icons

- **HTML updates**:
  - Added favicon link in `<head>`
  - Added Apple touch icon for iOS devices

Closes #4