### PR TITLE
Rename app to WeTravel

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -101,7 +101,7 @@ const App: React.FC = () => {
           ) : (
             <div className="flex items-center gap-2 animate-in fade-in duration-300">
               <div className="w-8 h-8 bg-terracotta-500 rounded-xl flex items-center justify-center shadow-lg shadow-terracotta-500/20"><Sparkles className="w-5 h-5 text-white" /></div>
-              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WanderList</h1>
+              <h1 className="text-xl font-serif font-bold text-ocean-900 dark:text-sand-50 tracking-tight">WeTravel</h1>
             </div>
           )}
           <ThemeToggle />

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -66,7 +66,7 @@ const InstallPrompt: React.FC = () => {
     <div className="fixed bottom-4 left-4 z-[100] bg-white text-ocean-900 p-4 rounded-xl shadow-2xl border border-sand-200 flex items-center gap-4 animate-in slide-in-from-bottom duration-300 max-w-sm">
       <div className="flex-1">
         <h3 className="font-bold text-sm mb-1">
-          Install WanderList
+          Install WeTravel
         </h3>
         <p className="text-xs text-sand-400">
           {isIOS 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#FDFCF8">
-    <title>WanderList AI</title>
+    <title>WeTravel</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "Trip Planner",
+  "name": "WeTravel",
   "description": "A comprehensive travel companion app to organize trips, view flight itineraries, discover new places, and visualize your journey on an interactive timeline and map.",
   "requestFramePermissions": [
     "geolocation"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "trip-planner",
+  "name": "wetravel",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "trip-planner",
+      "name": "wetravel",
       "version": "0.0.0",
       "dependencies": {
         "@google/genai": "^1.34.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "trip-planner",
+  "name": "wetravel",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,8 +23,8 @@ export default defineConfig(({ mode }) => {
           registerType: 'prompt',
           includeAssets: ['icon.svg'],
           manifest: {
-            name: 'WanderList Trip Planner',
-            short_name: 'WanderList',
+            name: 'WeTravel',
+            short_name: 'WeTravel',
             description: 'AI-powered travel planner for your next adventure',
             theme_color: '#FDFCF8', // bg-cream
             background_color: '#FDFCF8',


### PR DESCRIPTION
## Summary
- Renames the app from WanderList to WeTravel across all user-facing surfaces

## Changes
- `index.html`: Updated title tag
- `vite.config.ts`: Updated PWA manifest name and short_name
- `App.tsx`: Updated header text
- `InstallPrompt.tsx`: Updated install prompt text
- `metadata.json`: Updated app name
- `package.json` / `package-lock.json`: Updated package name

## Testing
- Build passes successfully

Closes #29